### PR TITLE
ECR-84 BE/fix: presinged url 접근 수정

### DIFF
--- a/api/src/main/java/org/example/educheck/domain/absenceattendance/controller/AbsenceAttendanceController.java
+++ b/api/src/main/java/org/example/educheck/domain/absenceattendance/controller/AbsenceAttendanceController.java
@@ -117,7 +117,7 @@ public class AbsenceAttendanceController {
         return ResponseEntity.ok(
                 ApiResponse.ok("유고 결석 신청 내역 상세 조회 성공",
                         "OK",
-                        absenceAttendanceService.getAbsenceAttendance(member, courseId, absenceAttendancesId))
+                        absenceAttendanceService.findAbsenceAttendanceById(member, courseId, absenceAttendancesId))
         );
     }
 

--- a/api/src/main/java/org/example/educheck/domain/absenceattendance/dto/response/AbsenceAttendanceResponseDto.java
+++ b/api/src/main/java/org/example/educheck/domain/absenceattendance/dto/response/AbsenceAttendanceResponseDto.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.educheck.domain.absenceattendance.entity.AbsenceAttendance;
-import org.example.educheck.domain.absenceattendanceattachmentfile.dto.response.AttachmentFileReposeDto;
+import org.example.educheck.domain.absenceattendanceattachmentfile.dto.response.AttachmentFileResponseDto;
 import org.example.educheck.domain.attendance.entity.AttendanceStatus;
 import org.example.educheck.domain.member.entity.Member;
 
@@ -32,9 +32,9 @@ public class AbsenceAttendanceResponseDto {
     private String reason;
     private LocalDateTime approveDateTime;
     private Character isApprove;
-    private List<AttachmentFileReposeDto> files;
+    private List<AttachmentFileResponseDto> files;
 
-    public static AbsenceAttendanceResponseDto from(AbsenceAttendance absenceAttendance, Member student, List<AttachmentFileReposeDto> files) {
+    public static AbsenceAttendanceResponseDto from(AbsenceAttendance absenceAttendance, Member student, List<AttachmentFileResponseDto> files) {
         return AbsenceAttendanceResponseDto.builder()
                 .absenceAttendanceId(absenceAttendance.getId())
                 .absenceAttendanceRequesterId(student.getId())

--- a/api/src/main/java/org/example/educheck/domain/absenceattendance/service/AbsenceAttendanceFinder.java
+++ b/api/src/main/java/org/example/educheck/domain/absenceattendance/service/AbsenceAttendanceFinder.java
@@ -1,0 +1,24 @@
+package org.example.educheck.domain.absenceattendance.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.educheck.domain.absenceattendance.entity.AbsenceAttendance;
+import org.example.educheck.domain.absenceattendance.repository.AbsenceAttendanceRepository;
+import org.example.educheck.global.common.exception.custom.common.ResourceNotFoundException;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AbsenceAttendanceFinder {
+
+    private final AbsenceAttendanceRepository absenceAttendanceRepository;
+
+    @Cacheable(value = "absenceAttendanceCache", key = "#absenceAttendancesId")
+    public AbsenceAttendance findAbsenceAttendanceById(Long absenceAttendancesId) {
+        return absenceAttendanceRepository.findById(absenceAttendancesId)
+                .orElseThrow(() -> new ResourceNotFoundException("해당 유고 결석 신청 내역이 존재하지 않습니다."));
+    }
+
+}

--- a/api/src/main/java/org/example/educheck/domain/absenceattendanceattachmentfile/dto/response/AttachmentFileResponseDto.java
+++ b/api/src/main/java/org/example/educheck/domain/absenceattendanceattachmentfile/dto/response/AttachmentFileResponseDto.java
@@ -11,18 +11,19 @@ import org.example.educheck.domain.absenceattendanceattachmentfile.entity.Absenc
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class AttachmentFileReposeDto {
+public class AttachmentFileResponseDto {
 
     private Long fileId;
     private String originalName;
     private String fileUrl;
+    private String s3Key;
     private String mine;
 
-    public static AttachmentFileReposeDto from(AbsenceAttendanceAttachmentFile file) {
-        return AttachmentFileReposeDto.builder()
+    public static AttachmentFileResponseDto from(AbsenceAttendanceAttachmentFile file, String accessUrl) {
+        return AttachmentFileResponseDto.builder()
                 .fileId(file.getId())
                 .originalName(file.getOriginalName())
-                .fileUrl(file.getUrl())
+                .fileUrl(accessUrl)
                 .mine(file.getMime())
                 .build();
 

--- a/api/src/main/java/org/example/educheck/domain/absenceattendanceattachmentfile/dto/response/AttachmentFileResponseDto.java
+++ b/api/src/main/java/org/example/educheck/domain/absenceattendanceattachmentfile/dto/response/AttachmentFileResponseDto.java
@@ -17,14 +17,15 @@ public class AttachmentFileResponseDto {
     private String originalName;
     private String fileUrl;
     private String s3Key;
-    private String mine;
+    private String mime;
 
     public static AttachmentFileResponseDto from(AbsenceAttendanceAttachmentFile file, String accessUrl) {
         return AttachmentFileResponseDto.builder()
                 .fileId(file.getId())
                 .originalName(file.getOriginalName())
                 .fileUrl(accessUrl)
-                .mine(file.getMime())
+                .s3Key(file.getS3Key())
+                .mime(file.getMime())
                 .build();
 
     }

--- a/api/src/main/java/org/example/educheck/domain/absenceattendanceattachmentfile/entity/AbsenceAttendanceAttachmentFile.java
+++ b/api/src/main/java/org/example/educheck/domain/absenceattendanceattachmentfile/entity/AbsenceAttendanceAttachmentFile.java
@@ -25,8 +25,6 @@ public class AbsenceAttendanceAttachmentFile extends BaseTimeEntity {
     @JoinColumn(name = "absence_attendance_id")
     private AbsenceAttendance absenceAttendance;
 
-    @Column(columnDefinition = "TEXT")
-    private String url;
     private String mime;
     private String originalName;
     //버킷 내 고유 식별자, 전체 경로 포함
@@ -35,9 +33,8 @@ public class AbsenceAttendanceAttachmentFile extends BaseTimeEntity {
     private LocalDateTime deletionRequestedAt;
 
     @Builder
-    public AbsenceAttendanceAttachmentFile(AbsenceAttendance absenceAttendance, String url, String originalName, String s3Key, String mime) {
+    public AbsenceAttendanceAttachmentFile(AbsenceAttendance absenceAttendance, String originalName, String s3Key, String mime) {
         this.absenceAttendance = absenceAttendance;
-        this.url = url;
         this.originalName = originalName;
         this.s3Key = s3Key;
         this.mime = mime;
@@ -52,7 +49,6 @@ public class AbsenceAttendanceAttachmentFile extends BaseTimeEntity {
         return "AbsenceAttendanceAttachmentFile{" +
                 "id=" + id +
                 ", absenceAttendance=" + absenceAttendance +
-                ", url='" + url + '\'' +
                 ", mime='" + mime + '\'' +
                 ", originalName='" + originalName + '\'' +
                 ", s3Key='" + s3Key + '\'' +

--- a/api/src/main/java/org/example/educheck/global/common/s3/S3Service.java
+++ b/api/src/main/java/org/example/educheck/global/common/s3/S3Service.java
@@ -93,7 +93,7 @@ public class S3Service {
         }
     }
 
-    public String generateViewPresignedUrl(String key) {
+    public String generateViewPresigndUrl(String key) {
         //조회 요청 정보 생성
         GetObjectRequest getObjectRequest = GetObjectRequest.builder()
                 .bucket(bucketName)

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -31,3 +31,5 @@ org.gradle.parallel=true
 org.gradle.daemon=false
 org.gradle.jvmargs=-Xmx5g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError
 org.gradle.workers.max=2
+
+logging.level.org.springframework.cache=TRACE

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -32,4 +32,4 @@ org.gradle.daemon=false
 org.gradle.jvmargs=-Xmx5g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError
 org.gradle.workers.max=2
 
-logging.level.org.springframework.cache=TRACE
+#logging.level.org.springframework.cache=TRACE

--- a/api/src/test/java/org/example/educheck/domain/absenceattendance/service/AbsenceAttendanceServiceTest.java
+++ b/api/src/test/java/org/example/educheck/domain/absenceattendance/service/AbsenceAttendanceServiceTest.java
@@ -95,12 +95,12 @@ class AbsenceAttendanceServiceTest {
         Long absenceAttendanceId = 1L;
         Long courseId = 1L;
 
-        AbsenceAttendanceResponseDto firstCall = absenceAttendanceService.getAbsenceAttendance(
+        AbsenceAttendanceResponseDto firstCall = absenceAttendanceService.findAbsenceAttendanceById(
                 mockMember, courseId, absenceAttendanceId
         );
 
         // 캐시 히트 예상
-        AbsenceAttendanceResponseDto secondCall = absenceAttendanceService.getAbsenceAttendance(
+        AbsenceAttendanceResponseDto secondCall = absenceAttendanceService.findAbsenceAttendanceById(
                 mockMember, courseId, absenceAttendanceId
         );
 
@@ -125,7 +125,7 @@ class AbsenceAttendanceServiceTest {
         Long absenceAttendanceId = 1L;
         Long courseId = 1L;
 
-        absenceAttendanceService.getAbsenceAttendance(
+        absenceAttendanceService.findAbsenceAttendanceById(
                 mockMember, courseId, absenceAttendanceId
         );
 
@@ -142,11 +142,11 @@ class AbsenceAttendanceServiceTest {
         Long absenceAttendanceId = 1L;
         Long courseId = 1L;
 
-        absenceAttendanceService.getAbsenceAttendance(
+        absenceAttendanceService.findAbsenceAttendanceById(
                 mockMember, courseId, absenceAttendanceId
         );
 
-        absenceAttendanceService.getAbsenceAttendance(
+        absenceAttendanceService.findAbsenceAttendanceById(
                 mockMember, courseId, absenceAttendanceId
         );
 
@@ -162,17 +162,17 @@ class AbsenceAttendanceServiceTest {
         Long absenceAttendanceId = 1L;
         Long courseId = 1L;
 
-        AbsenceAttendanceResponseDto firstResult = absenceAttendanceService.getAbsenceAttendance(
+        AbsenceAttendanceResponseDto firstResult = absenceAttendanceService.findAbsenceAttendanceById(
                 mockMember, courseId, absenceAttendanceId
         );
 
-        AbsenceAttendanceResponseDto cachedResult = absenceAttendanceService.getAbsenceAttendance(
+        AbsenceAttendanceResponseDto cachedResult = absenceAttendanceService.findAbsenceAttendanceById(
                 mockMember, courseId, absenceAttendanceId
         );
 
         absenceAttendanceService.cancelAttendanceAbsence(mockMember, absenceAttendanceId);
 
-        AbsenceAttendanceResponseDto afterResult = absenceAttendanceService.getAbsenceAttendance(
+        AbsenceAttendanceResponseDto afterResult = absenceAttendanceService.findAbsenceAttendanceById(
                 mockMember, courseId, absenceAttendanceId
         );
 
@@ -195,7 +195,7 @@ class AbsenceAttendanceServiceTest {
                      .when(absenceAttendanceRepository)
                      .findById(i);
 
-             absenceAttendanceService.getAbsenceAttendance(mockMember, 1L, i);
+             absenceAttendanceService.findAbsenceAttendanceById(mockMember, 1L, i);
         }
 
         Cache cache = cacheManager.getCache("absenceAttendanceCache");
@@ -239,11 +239,11 @@ class AbsenceAttendanceServiceTest {
                 .findById(nonExistedId);
 
         assertThatThrownBy(() ->
-                absenceAttendanceService.getAbsenceAttendance(mockMember, courseId, nonExistedId))
+                absenceAttendanceService.findAbsenceAttendanceById(mockMember, courseId, nonExistedId))
                 .isInstanceOf(ResourceNotFoundException.class);
 
         assertThatThrownBy(() ->
-                absenceAttendanceService.getAbsenceAttendance(mockMember, courseId, nonExistedId))
+                absenceAttendanceService.findAbsenceAttendanceById(mockMember, courseId, nonExistedId))
                 .isInstanceOf(ResourceNotFoundException.class);
 
         verify(absenceAttendanceRepository, times(2)).findById(nonExistedId);


### PR DESCRIPTION
## 🔍 관련 Jira 이슈

- ECR-84

## 📝 변경 사항

-  요청시 s3key를 통해 GET URL 동적으로 생성하도록 변경
-  Cache 적용 범위 변경
   - AbsenceAttendacne + S3 url -> AbsenceAttendance 캐시 적용

## ✅ PR 체크리스트

- [x] 커밋 메시지에 Jira 이슈 번호 포함
- [ ] 관련 문서 업데이트 (필요한 경우)
- [x] Jira 이슈 상태 업데이트

## 📌 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 결석 출석 정보 조회를 위한 전용 서비스가 추가되었습니다.

* **버그 수정**
  * 첨부파일 DTO의 오타가 수정되어 올바른 타입이 적용되었습니다.

* **리팩터링**
  * 결석 출석 정보 조회 방식이 서비스 분리 및 캐시 미적용 방식으로 개선되었습니다.
  * 첨부파일 URL 생성 및 저장 방식이 변경되었습니다.
  * 첨부파일 응답 DTO에 s3Key와 mime 필드가 추가되었습니다.

* **테스트**
  * 서비스 메서드명 변경에 따라 테스트 코드가 업데이트되었습니다.

* **환경 설정**
  * Spring Cache 로깅 레벨이 TRACE로 추가 설정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->