### PR TITLE
[ECR-94] refactor: NoticeService에서 RabbitTemplate 직접 의존 제거 및 이벤트 기반

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -67,6 +67,7 @@ dependencies {
     testImplementation "org.awaitility:awaitility:4.2.0"
     testImplementation "org.testcontainers:rabbitmq:1.18.0"
     implementation 'org.springframework.retry:spring-retry'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
 }
 
 tasks.named('test') {

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-admin:9.2.0'
     testImplementation "org.awaitility:awaitility:4.2.0"
     testImplementation "org.testcontainers:rabbitmq:1.18.0"
-
+    implementation 'org.springframework.retry:spring-retry'
 }
 
 tasks.named('test') {

--- a/api/src/main/java/org/example/educheck/ApiApplication.java
+++ b/api/src/main/java/org/example/educheck/ApiApplication.java
@@ -3,7 +3,9 @@ package org.example.educheck;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.retry.annotation.EnableRetry;
 
+@EnableRetry
 @EnableJpaAuditing
 @SpringBootApplication
 public class ApiApplication {

--- a/api/src/main/java/org/example/educheck/domain/notice/event/NoticeCreatedEvent.java
+++ b/api/src/main/java/org/example/educheck/domain/notice/event/NoticeCreatedEvent.java
@@ -1,0 +1,17 @@
+package org.example.educheck.domain.notice.event;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.example.educheck.global.rabbitmq.dto.NoticeMessageDto;
+
+@Getter
+@RequiredArgsConstructor
+public class NoticeCreatedEvent {
+
+    private final NoticeMessageDto noticeMessageDto;
+
+    public static NoticeCreatedEvent create(NoticeMessageDto noticeMessageDto) {
+        return new NoticeCreatedEvent(noticeMessageDto);
+    }
+}

--- a/api/src/main/java/org/example/educheck/domain/notice/event/NoticeCreatedEvent.java
+++ b/api/src/main/java/org/example/educheck/domain/notice/event/NoticeCreatedEvent.java
@@ -1,6 +1,5 @@
 package org.example.educheck.domain.notice.event;
 
-import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.example.educheck.global.rabbitmq.dto.NoticeMessageDto;

--- a/api/src/main/java/org/example/educheck/domain/notice/listener/NoticeEventListener.java
+++ b/api/src/main/java/org/example/educheck/domain/notice/listener/NoticeEventListener.java
@@ -1,0 +1,23 @@
+package org.example.educheck.domain.notice.listener;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.educheck.domain.notice.event.NoticeCreatedEvent;
+import org.example.educheck.domain.notice.port.out.NoticeEventPublisherPort;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NoticeEventListener {
+
+    private final NoticeEventPublisherPort noticeEventPublisherPort;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleNoticeCreatedEvent(NoticeCreatedEvent event) {
+        log.info("noticeEventListener 수신 : {}", event);
+        noticeEventPublisherPort.publish(event.getNoticeMessageDto());
+    }
+}

--- a/api/src/main/java/org/example/educheck/domain/notice/port/out/NoticeEventPublisherPort.java
+++ b/api/src/main/java/org/example/educheck/domain/notice/port/out/NoticeEventPublisherPort.java
@@ -1,0 +1,8 @@
+package org.example.educheck.domain.notice.port.out;
+
+import org.example.educheck.global.rabbitmq.dto.NoticeMessageDto;
+
+public interface NoticeEventPublisherPort {
+
+    void publish(NoticeMessageDto messageDto);
+}

--- a/api/src/main/java/org/example/educheck/domain/notice/service/NoticeService.java
+++ b/api/src/main/java/org/example/educheck/domain/notice/service/NoticeService.java
@@ -11,7 +11,6 @@ import org.example.educheck.domain.notice.dto.response.NoticeDetailResponseDto;
 import org.example.educheck.domain.notice.dto.response.NoticeListResponseDto;
 import org.example.educheck.domain.notice.entity.Notice;
 import org.example.educheck.domain.notice.event.NoticeCreatedEvent;
-import org.example.educheck.domain.notice.port.out.NoticeEventPublisherPort;
 import org.example.educheck.domain.notice.repository.NoticeRepository;
 import org.example.educheck.global.common.exception.custom.common.InvalidRequestException;
 import org.example.educheck.global.common.exception.custom.common.ResourceNotFoundException;

--- a/api/src/main/java/org/example/educheck/global/common/entity/FailStatus.java
+++ b/api/src/main/java/org/example/educheck/global/common/entity/FailStatus.java
@@ -1,0 +1,5 @@
+package org.example.educheck.global.common.entity;
+
+public enum FailStatus {
+    PENDING, RETRYING, RESOLVED, FAILED
+}

--- a/api/src/main/java/org/example/educheck/global/common/entity/ProducerFailedEvent.java
+++ b/api/src/main/java/org/example/educheck/global/common/entity/ProducerFailedEvent.java
@@ -42,7 +42,8 @@ public class ProducerFailedEvent {
     private String errorMessage;
 
     @Column(nullable = false)
-    private Integer retryCount;
+    @Builder.Default
+    private Integer retryCount = 0;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)

--- a/api/src/main/java/org/example/educheck/global/common/entity/ProducerFailedEvent.java
+++ b/api/src/main/java/org/example/educheck/global/common/entity/ProducerFailedEvent.java
@@ -1,0 +1,71 @@
+package org.example.educheck.global.common.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Table(name = "producer_failed_events",
+        indexes = {
+                @Index(name = "idx_status_created", columnList = "status, created_at"),
+                @Index(name = "idx_entity_type_id", columnList = "entity_type, entity_id")
+        })@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class ProducerFailedEvent {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String entityType;
+
+    @Column(nullable = false)
+    private String entityId;
+
+    @Column(nullable = false)
+    private String targetExchange;
+
+    @Column(nullable = false)
+    private String targetRoutingKey;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String payload; // JSON
+
+    @Column(columnDefinition = "TEXT")
+    private String errorMessage;
+
+    @Column(nullable = false)
+    private Integer retryCount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private FailStatus status; // PENDING, RETRYING, RESOLVED, FAILED
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    private LocalDateTime lastRetryAt;
+
+    private LocalDateTime resolvedAt;
+
+    public void incrementRetryCount() {
+        this.retryCount++;
+        this.lastRetryAt = LocalDateTime.now();
+    }
+
+    public void markResolved() {
+        this.status = FailStatus.RESOLVED;
+        this.resolvedAt = LocalDateTime.now();
+    }
+
+    public void markFailed() {
+        this.status = FailStatus.FAILED;
+    }
+}

--- a/api/src/main/java/org/example/educheck/global/common/repository/ProducerFailedEventRepository.java
+++ b/api/src/main/java/org/example/educheck/global/common/repository/ProducerFailedEventRepository.java
@@ -1,4 +1,4 @@
-package org.example.educheck.global.common.repotiroy;
+package org.example.educheck.global.common.repository;
 
 import org.example.educheck.global.common.entity.ProducerFailedEvent;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/api/src/main/java/org/example/educheck/global/common/repository/ProducerFailedEventRepository.java
+++ b/api/src/main/java/org/example/educheck/global/common/repository/ProducerFailedEventRepository.java
@@ -3,5 +3,5 @@ package org.example.educheck.global.common.repository;
 import org.example.educheck.global.common.entity.ProducerFailedEvent;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ProducerFailedEventRepository extends JpaRepository<ProducerFailedEvent, Integer> {
+public interface ProducerFailedEventRepository extends JpaRepository<ProducerFailedEvent, Long> {
 }

--- a/api/src/main/java/org/example/educheck/global/common/repotiroy/ProducerFailedEventRepository.java
+++ b/api/src/main/java/org/example/educheck/global/common/repotiroy/ProducerFailedEventRepository.java
@@ -1,0 +1,7 @@
+package org.example.educheck.global.common.repotiroy;
+
+import org.example.educheck.global.common.entity.ProducerFailedEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProducerFailedEventRepository extends JpaRepository<ProducerFailedEvent, Integer> {
+}

--- a/api/src/main/java/org/example/educheck/global/rabbitmq/RabbitMQNoticeAdapter.java
+++ b/api/src/main/java/org/example/educheck/global/rabbitmq/RabbitMQNoticeAdapter.java
@@ -4,8 +4,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.educheck.domain.notice.port.out.NoticeEventPublisherPort;
 import org.example.educheck.global.rabbitmq.dto.NoticeMessageDto;
+import org.springframework.amqp.AmqpException;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -21,12 +25,24 @@ public class RabbitMQNoticeAdapter implements NoticeEventPublisherPort {
 
     private final RabbitTemplate rabbitTemplate;
 
-
+    @Retryable(
+            value = {AmqpException.class},
+            maxAttempts = 2,
+            backoff = @Backoff(delay = 1000, multiplier = 2)
+    )
     @Override
     public void publish(NoticeMessageDto messageDto) {
         String routingKey = getRoutingKey(messageDto.getCourseId());
-        log.info("rabbitmq event publish");
-        rabbitTemplate.convertAndSend(exchangeName, routingKey, messageDto);
+            rabbitTemplate.convertAndSend(exchangeName, routingKey, messageDto);
+    }
+
+    @Recover
+    public void recover(AmqpException e, NoticeMessageDto messageDto) {
+        log.error("재시도 후 최종 실패 - courseId: {}", messageDto.getCourseId(), e);
+
+        //fail 테이블에 저장
+
+        //TODO: 슬랙알림 연동
     }
 
     private String getRoutingKey(Long courseId) {

--- a/api/src/main/java/org/example/educheck/global/rabbitmq/RabbitMQNoticeAdapter.java
+++ b/api/src/main/java/org/example/educheck/global/rabbitmq/RabbitMQNoticeAdapter.java
@@ -1,0 +1,36 @@
+package org.example.educheck.global.rabbitmq;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.educheck.domain.notice.port.out.NoticeEventPublisherPort;
+import org.example.educheck.global.rabbitmq.dto.NoticeMessageDto;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RabbitMQNoticeAdapter implements NoticeEventPublisherPort {
+
+    @Value("${educheck.rabbitmq.exchange.notice}")
+    private String exchangeName;
+
+    @Value("${educheck.rabbitmq.routing-key.format.send}")
+    private String routingKeyFormat;
+
+    private final RabbitTemplate rabbitTemplate;
+
+
+    @Override
+    public void publish(NoticeMessageDto messageDto) {
+        String routingKey = getRoutingKey(messageDto.getCourseId());
+        log.info("rabbitmq event publish");
+        rabbitTemplate.convertAndSend(exchangeName, routingKey, messageDto);
+    }
+
+    private String getRoutingKey(Long courseId) {
+        return String.format(routingKeyFormat, courseId);
+    }
+
+}

--- a/api/src/main/java/org/example/educheck/global/rabbitmq/RabbitMQNoticeAdapter.java
+++ b/api/src/main/java/org/example/educheck/global/rabbitmq/RabbitMQNoticeAdapter.java
@@ -7,7 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.example.educheck.domain.notice.port.out.NoticeEventPublisherPort;
 import org.example.educheck.global.common.entity.FailStatus;
 import org.example.educheck.global.common.entity.ProducerFailedEvent;
-import org.example.educheck.global.common.repotiroy.ProducerFailedEventRepository;
+import org.example.educheck.global.common.repository.ProducerFailedEventRepository;
 import org.example.educheck.global.rabbitmq.dto.NoticeMessageDto;
 import org.springframework.amqp.AmqpException;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;

--- a/api/src/main/java/org/example/educheck/global/rabbitmq/RabbitMQNoticeAdapter.java
+++ b/api/src/main/java/org/example/educheck/global/rabbitmq/RabbitMQNoticeAdapter.java
@@ -1,8 +1,13 @@
 package org.example.educheck.global.rabbitmq;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.educheck.domain.notice.port.out.NoticeEventPublisherPort;
+import org.example.educheck.global.common.entity.FailStatus;
+import org.example.educheck.global.common.entity.ProducerFailedEvent;
+import org.example.educheck.global.common.repotiroy.ProducerFailedEventRepository;
 import org.example.educheck.global.rabbitmq.dto.NoticeMessageDto;
 import org.springframework.amqp.AmqpException;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
@@ -11,6 +16,8 @@ import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Recover;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
 
 @Slf4j
 @Component
@@ -25,28 +32,58 @@ public class RabbitMQNoticeAdapter implements NoticeEventPublisherPort {
 
     private final RabbitTemplate rabbitTemplate;
 
+    private final ObjectMapper objectMapper;
+
+    private final ProducerFailedEventRepository producerFailedEventRepository;
+
     @Retryable(
             value = {AmqpException.class},
-            maxAttempts = 2,
+            maxAttempts = 3,
             backoff = @Backoff(delay = 1000, multiplier = 2)
     )
     @Override
     public void publish(NoticeMessageDto messageDto) {
         String routingKey = getRoutingKey(messageDto.getCourseId());
+        try {
             rabbitTemplate.convertAndSend(exchangeName, routingKey, messageDto);
+            log.debug("메시지 전송 성공 - courseId: {}, routingKey: {}", messageDto.getCourseId(), routingKey);
+        } catch (AmqpException e) {
+            log.warn("메시지 전송 실패 - courseId: {}, 재시도 예정", messageDto.getCourseId());
+            throw e;
+        }
     }
 
     @Recover
     public void recover(AmqpException e, NoticeMessageDto messageDto) {
         log.error("재시도 후 최종 실패 - courseId: {}", messageDto.getCourseId(), e);
 
-        //fail 테이블에 저장
+        ProducerFailedEvent failedNotice = ProducerFailedEvent.builder()
+                .entityType("NOTICE")
+                .entityId(String.valueOf(messageDto.getNoticeId()))
+                .targetExchange(exchangeName)
+                .targetRoutingKey(getRoutingKey(messageDto.getCourseId()))
+                .payload(toJson(messageDto))
+                .errorMessage(e.getMessage())
+                .status(FailStatus.PENDING)
+                .retryCount(0)
+                .createdAt(LocalDateTime.now())
+                .build();
 
+        producerFailedEventRepository.save(failedNotice);
         //TODO: 슬랙알림 연동
     }
 
     private String getRoutingKey(Long courseId) {
         return String.format(routingKeyFormat, courseId);
+    }
+
+    private String toJson(NoticeMessageDto messageDto) {
+        try {
+            return objectMapper.writeValueAsString(messageDto);
+        } catch (JsonProcessingException e) {
+            log.error("JSON 변환 실패", e);
+            return messageDto.toString();
+        }
     }
 
 }


### PR DESCRIPTION
구조로 변경

- NoticeService에서 RabbitTemplate을 직접 호출하던 로직 제거
- NoticeCreatedEvent 발행 후 이벤트리스너에서 처리하도록 변경
- NoticeEventPublisherPort 인터페이스와 RabbitMQNoticeAdaptor 구현체 추가 서비스레이어가 인프라 레이어에 의존하지 않도록 DIP 적용

## 🔍 관련 Jira 이슈

- ECR-94

## 📝 변경 사항

## ✅ PR 체크리스트

- [ ] 커밋 메시지에 Jira 이슈 번호 포함
- [ ] 관련 문서 업데이트 (필요한 경우)
- [ ] Jira 이슈 상태 업데이트

## 📌 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 공지사항 전송에 재시도 메커니즘 추가로 전송 신뢰성 향상
  * 실패한 공지사항 전송을 자동으로 추적하고 복구하는 기능 추가
  * 이벤트 기반 공지사항 발행 시스템 도입으로 시스템 탄력성 개선

* **개선 사항**
  * 공지사항 전송 프로세스의 트랜잭션 경계 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->